### PR TITLE
[DisplayUsernames] Replaced link for 0PluginLibrary.plugin.js

### DIFF
--- a/DisplayUsernames/DisplayUsernames.plugin.js
+++ b/DisplayUsernames/DisplayUsernames.plugin.js
@@ -125,9 +125,9 @@ module.exports = !global.ZeresPluginLibrary ? class {
 			confirmText: "Download",
 			cancelText: "Cancel",
 			onConfirm: () => {
-				request.get("https://rauenzi.github.io/BDPluginLibrary/release/0PluginLibrary.plugin.js", (error, response, body) => {
+				request.get("https://github.com/zerebos/BDPluginLibrary/raw/master/release/0PluginLibrary.plugin.js", (error, response, body) => {
 					if (error)
-						return electron.shell.openExternal("https://betterdiscord.net/ghdl?url=https://raw.githubusercontent.com/rauenzi/BDPluginLibrary/master/release/0PluginLibrary.plugin.js");
+						return electron.shell.openExternal("https://betterdiscord.net/ghdl?url=https://github.com/zerebos/BDPluginLibrary/raw/master/release/0PluginLibrary.plugin.js");
 
 					fs.writeFileSync(path.join(BdApi.Plugins.folder, "0PluginLibrary.plugin.js"), body);
 				});


### PR DESCRIPTION
The old link gave a 404, the new link exist and is working with the plugin.